### PR TITLE
Do not try to commit when the working copy is clean.

### DIFF
--- a/lib/autogit.php
+++ b/lib/autogit.php
@@ -45,6 +45,10 @@ class Autogit extends Git
 
     public function commit($message)
     {
+        if ($this->isWorkingCopyClean()) {
+            return;
+        }
+
         $this->execute(sprintf(
             'commit --author %s --message %s',
             escapeshellarg($this->author()),


### PR DESCRIPTION
This makes sure that there is no error when the working copy is clean, but the hook was called anyway.

This is a temporary fix until https://github.com/pedroborges/kirby-autogit/pull/50 is merged.